### PR TITLE
IHRAA-17851 - Update dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,5 +17,5 @@ android {
 }
 
 dependencies {
-  implementation "com.google.android.gms:play-services-ads-identifier:$googlePlayServicesAdIdVersion"
+  implementation 'com.google.android.gms:play-services-ads-identifier:18.1.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,5 +17,5 @@ android {
 }
 
 dependencies {
-  implementation 'com.google.android.gms:play-services-ads-lite:22.2.0'
+  implementation "com.google.android.gms:play-services-ads-identifier:$googlePlayServicesAdIdVersion"
 }


### PR DESCRIPTION
`com.google.android.gms:play-services-ads-lite:22.2.0` is getting transitively upgraded to version 23.3.0 by the firebase BOM.

If we manually upgrade that dependency 23.3.0, then `AdvertisingIdClient.getAdvertisingIdInfo()` and the associated types cannot be resolved, making the addition of `com.google.android.gms:play-services-ads-identifier` necessary.

The only reason this code calls into play services is to get `AdvertisingIdClient.Info` which hold the advertising id as well as opt-in/out for targeted ads.  This is provided by `com.google.android.gms:play-services-ads-identifier`, so I'm removing ads-lite dependency.